### PR TITLE
Tristan Linehan / C-Web-Server

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -17,7 +17,9 @@ struct cache_entry *alloc_entry(char *path, char *content_type, void *content, i
 /**
  * Deallocate a cache entry
  */
-void free_entry(void *v_ent, void *varg)
+// void free_entry(void *v_ent, void *varg)
+// below fixes above bug, when executing MAKE
+void free_entry(struct cache_entry *entry)
 {
     ///////////////////
     // IMPLEMENT ME! //

--- a/src/server.c
+++ b/src/server.c
@@ -48,8 +48,44 @@
  * 
  * Return the value from the send() function.
  */
+/* EXAMPLE RESPONSE
+HTTP/1.1 200 OK
+Date: Wed Dec 20 13:05:11 PST 2017
+Connection: close
+Content-Length: 41749
+Content-Type: text/html
+
+<!DOCTYPE html><html><head><title>Lambda School ...
+
+*** The end of the header on both the request and response is marked by a blank line (i.e. two newlines in a row).
+*/
+void get_time(char *return_time)
+{
+    time_t current_time;
+    struct tm *local_time;
+    char *created_time; 
+
+    current_time = time(NULL);
+    local_time = localtime( &current_time );
+    // printf("%s\n", asctime (local_time));
+    created_time = asctime (local_time);
+    // printf("created_time: %s\n", created_time);
+    sprintf(return_time,"%s", created_time);
+    // printf("created_time after sprintf: %s\n", created_time);
+    *return_time = *created_time;
+    // NO NEED TO RETURN
+}
 int send_response(int fd, char *header, char *content_type, void *body, int content_length)
 {
+    /*
+        //  (void)header;
+        //  (void)content_type;
+        //  (void)body;
+        //  (void)content_length;
+        //  (void)fd;
+        //  (void)response;
+        //  (void)max_response_size;
+    */
     const int max_response_size = 65536;
     char response[max_response_size];
 
@@ -58,7 +94,15 @@ int send_response(int fd, char *header, char *content_type, void *body, int cont
     ///////////////////
     // IMPLEMENT ME! //
     ///////////////////
+    char return_time[80];
+    get_time(return_time);
+    // printf("return_time from send():%s\n", return_time);
+    // printf("sizeof:%ld\n", sizeof(return_time));
+    int res_len = sprintf(response, "HTTP/1.1 %s\nDate:%sConnection: close\nContent-Length: %i\nContent-Type: %s\n\n%s\n\n", header, return_time, content_length, content_type, body);
+    // printf("dest:%s\n", body);
+    printf("  <-- <start of res>\n%s    <end of res>\n", response);
 
+    int response_length = res_len;
     // Send it all!
     int rv = send(fd, response, response_length, 0);
 
@@ -75,17 +119,37 @@ int send_response(int fd, char *header, char *content_type, void *body, int cont
  */
 void get_d20(int fd)
 {
+    // (void)fd;
     // Generate a random number between 1 and 20 inclusive
     
     ///////////////////
     // IMPLEMENT ME! //
     ///////////////////
+    int random_num;
+    srand(time(NULL));
+    random_num = rand() % 20 +1;
+    // printf("%i\n", random_num);
+
+    // (void)random_num;
 
     // Use send_response() to send it back as text/plain data
 
     ///////////////////
     // IMPLEMENT ME! //
     ///////////////////
+    // send_response(int fd, char *header, char *content_type, void *body, int content_length)
+    //send_response(fd, "HTTP/1.1 404 NOT FOUND", mime_type, filedata->data, filedata->size);
+// ^- REF ONLY
+    char body[2];    
+    int len_body = sprintf(body, "%i", random_num);
+    // printf("src:%i\n", random_num);
+    // printf("1:%i\n", ret_val);
+     // BELOW, SAME VALUE AS RETURNED FROM SPRINTF
+     // int ret_val_two = strlen(body);
+    // printf("2:%i\n", ret_val_two);
+    // printf("3:%i\n", len_body);
+
+    send_response(fd, "201 CREATED", "text/plain", body, len_body);
 }
 
 /**
@@ -119,6 +183,9 @@ void resp_404(int fd)
  */
 void get_file(int fd, struct cache *cache, char *request_path)
 {
+     (void)fd;
+     (void)cache;
+     (void)request_path;
     ///////////////////
     // IMPLEMENT ME! //
     ///////////////////
@@ -132,9 +199,11 @@ void get_file(int fd, struct cache *cache, char *request_path)
  */
 char *find_start_of_body(char *header)
 {
+     (void)header;
     ///////////////////
     // IMPLEMENT ME! // (Stretch)
     ///////////////////
+     return(0);
 }
 
 /**
@@ -142,6 +211,7 @@ char *find_start_of_body(char *header)
  */
 void handle_http_request(int fd, struct cache *cache)
 {
+     (void)cache;
     const int request_buffer_size = 65536; // 64K
     char request[request_buffer_size];
 
@@ -157,14 +227,44 @@ void handle_http_request(int fd, struct cache *cache)
     ///////////////////
     // IMPLEMENT ME! //
     ///////////////////
+     // printf("--> incoming request:\n%s<end of req>\n",request);
+    // RETURNS:
+        // GET /test HTTP/1.1
+        // Host: localhost:3490
+        // User-Agent: curl/7.61.1
+        // Accept: */*
 
     // Read the three components of the first request line
+    char req_type[5];
+    char req_endpoint[20];
+    // SSCANF BREAKS DOWN THE REQ INTO VARs
+    sscanf(request, "%s %s", req_type, req_endpoint);
+    // printf("req_type: %s\nreq_endpoint: %s\n", req_type, req_endpoint);
+    printf("  --> incoming request: %s %s\n", req_type, req_endpoint);
+
+    if (strlen(req_endpoint) > 1) {
+        // MEMMOVE, REMOVES THE LEADING '/'
+        memmove(req_endpoint, req_endpoint+1, strlen(req_endpoint));
+        // printf("NEW req_endpoint: %s\n", req_endpoint);
+    }
+    // printf("NEW req_endpoint: %s\n", req_endpoint);
 
     // If GET, handle the get endpoints
 
+    if (strcmp(req_type, "GET") == 0) {
+        // printf("found GET in req\n");
+        if (strcmp(req_endpoint, "/") == 0) {
+            printf("found HOME\n");
+            return;
+        }
     //    Check if it's /d20 and handle that special case
+        else if (strcmp(req_endpoint, "d20") == 0) {
+            // printf("found d20 in endpoint\n");
+            get_d20(fd);
+        }
     //    Otherwise serve the requested file by calling get_file()
 
+    }
 
     // (Stretch) If POST, handle the post request
 }


### PR DESCRIPTION
#### Days 1 and 2

1. 
- [ ]   Examine `handle_http_request()` in the file `server.c`.
- [ ]   Parse first line of HTTP request header for a `GET` or `POST`, and path.
- [ ]   Read the three components from the first line of the HTTP header.
- [ ]   You can start by just checking for `/d20`  
- [ ]   and then add arbitrary files later.
- [ ]   If you can't find an appropriate handler, call `resp_404()`

2. 
- [ ]   Implement the `get_d20()` handler. This will call `send_response()`.

3. 
- [ ]   Implement `send_response()`.
- [ ]   This needs to build a complete HTTP response with the given parameters. It
   should write the response to the string in the `response` variable.   
- [ ]   The total length of the header **and** body should be stored in the
   `response_length` variable 

4. 
- [ ]   Implement arbitrary file serving.
- [ ]   Any other URL should map to the `serverroot` directory and files that lie
   within. 
#### Days 3 and 4

- [ ] Implement an LRU cache. This will be used to cache files in RAM so you don't
have to load them through the OS.

- [ ] When a file is requested, the cache should be checked to see if it is there.
If so, the file is served from the cache. If not, the file is loaded from
disk, served, and saved to the cache.

1. 
- [ ] Implement `cache_put()` in `cache.c`.

   Algorithm:

   * Allocate a new cache entry with the passed parameters.
   * Insert the entry at the head of the doubly-linked list.
   * Store the entry in the hashtable as well, indexed by the entry's `path`.
   * Increment the current size of the cache.
   * If the cache size is greater than the max size:
     * Remove the entry from the hashtable, using the entry's `path` and the `hashtable_delete` function.
     * Remove the cache entry at the tail of the linked list.
     * Free the cache entry.
     * Ensure the size counter for the number of entries in the cache is correct.

2. 
- [ ] Implement `cache_get()` in `cache.c`.

   Algorithm:

   * Attempt to find the cache entry pointer by `path` in the hash table.
   * If not found, return `NULL`.
   * Move the cache entry to the head of the doubly-linked list.
   * Return the cache entry pointer.

3. 
- [ ] Add caching functionality to `server.c`.

   When a file is requested, first check to see if the path to the file is in
   the cache (use the file path as the key).

   If it's there, serve it back.

   If it's not there:

   * Load the file from disk (see `file.c`)
   * Store it in the cache
   * Serve it

- [ ] There's a set of unit tests included to ensure that your cache implementation is functioning correctly. From the `src` directory, run `make tests` in order to run the unit tests against your implementation. 

### Stretch Goals

#### 1. Post a file
- [ ] Stretch1

1. Implement `find_start_of_body()` to locate the start of the HTTP request body
   (just after the header).

2. Implement the `post_save()` handler. Modify the main loop to pass the body
   into it. Have this handler write the file to disk. Hint: `open()`, `write()`,
   `close()`. `fopen()`, `fwrite()`, and `fclose()` variants can also be used,
   but the former three functions will be slightly more straightforward to use
   in this case.

   The response from `post_save()` should be of type `application/json` and
   should be `{"status":"ok"}`.

#### 2. Automatic `index.html` serving
- [ ] Stretch2

We know that if the user hits `http://localhost:3490/index.html` it should
return the file at `./serverroot/index.html`.

Make it so that if the user hits `http://localhost:3490/` (which is endpoint
`/`, on disk `./serverroot/`), if no file is found there, try adding an
`index.html` to the end of the path and trying again.

So `http://localhost:3490/` would first try:

```
./serverroot/
```

fail to find a file there, then try:

```
./serverroot/index.html
```

and succeed.

#### 3. Expire cache entries
- [ ] Stretch3

It doesn't make sense to cache things forever--what if the file changes on disk?

Add a `created_at` timestamp to cache entries.

If an item is found in the cache, check to see if it is more than 1 minute old. If it is, delete it from the cache, then load the new one from disk as if it weren't found.

You'll have to add a `cache_delete` function to your cache code that does the work of actually removing entries that are too old from the cache.

#### 4. Concurrency
- [ ] Stretch4


_Difficulty: Pretty Dang Tough_

Research the pthreads library.

When a new connection comes in, launch a thread to handle it.

Be sure to lock the cache when a thread accesses it so the threads don't step on each other's toes and corrupt the cache.

Also have thread cleanup handlers to handle threads that have died.

