### PR TITLE
Tim Zulf- WIP:

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -6,6 +6,7 @@
 
 /**
  * Allocate a cache entry
+ LRU cache stuff
  */
 struct cache_entry *alloc_entry(char *path, char *content_type, void *content, int content_length)
 {
@@ -68,7 +69,7 @@ void dllist_move_to_head(struct cache *cache, struct cache_entry *ce)
 
 /**
  * Removes the tail from the list and returns it
- * 
+ *
  * NOTE: does not deallocate the tail
  */
 struct cache_entry *dllist_remove_tail(struct cache *cache)
@@ -85,7 +86,7 @@ struct cache_entry *dllist_remove_tail(struct cache *cache)
 
 /**
  * Create a new cache
- * 
+ *
  * max_size: maximum number of entries in the cache
  * hashsize: hashtable size (0 for default)
  */
@@ -117,7 +118,7 @@ void cache_free(struct cache *cache)
  * Store an entry in the cache
  *
  * This will also remove the least-recently-used items as necessary.
- * 
+ *
  * NOTE: doesn't check for duplicate cache entries
  */
 void cache_put(struct cache *cache, char *path, char *content_type, void *content, int content_length)

--- a/src/server.c
+++ b/src/server.c
@@ -1,18 +1,18 @@
 /**
  * webserver.c -- A webserver written in C
- * 
+ *
  * Test with curl (if you don't have it, install it):
- * 
+ *
  *    curl -D - http://localhost:3490/
  *    curl -D - http://localhost:3490/d20
  *    curl -D - http://localhost:3490/date
- * 
+ *
  * You can also test the above URLs in your browser! They should work!
- * 
+ *
  * Posting Data:
- * 
+ *
  *    curl -D - -X POST -H 'Content-Type: text/plain' -d 'Hello, sample data!' http://localhost:3490/save
- * 
+ *
  * (Posting data is harder to test from a browser.)
  */
 
@@ -45,13 +45,21 @@
  * header:       "HTTP/1.1 404 NOT FOUND" or "HTTP/1.1 200 OK", etc.
  * content_type: "text/plain", etc.
  * body:         the data to send.
- * 
+ *
  * Return the value from the send() function.
  */
 int send_response(int fd, char *header, char *content_type, void *body, int content_length)
 {
+  // this function builds an HTTP response with all the given parameters: header, content_type, body the actual
+  // content of the request, and content_length the total length of the header and body of the response in bytes
+  // this is so the send() function below  recieves the respond legnth which it needs to snned a message on a socket.
     const int max_response_size = 65536;
     char response[max_response_size];
+    // response is an array of characers so do I need:
+    // response_length = sizeof(respone)/sizeof(char)?
+    // just initalize response length for now
+    int response_length[0];
+
 
     // Build HTTP response and store it in response
 
@@ -76,7 +84,7 @@ int send_response(int fd, char *header, char *content_type, void *body, int cont
 void get_d20(int fd)
 {
     // Generate a random number between 1 and 20 inclusive
-    
+
     ///////////////////
     // IMPLEMENT ME! //
     ///////////////////
@@ -94,7 +102,7 @@ void get_d20(int fd)
 void resp_404(int fd)
 {
     char filepath[4096];
-    struct file_data *filedata; 
+    struct file_data *filedata;
     char *mime_type;
 
     // Fetch the 404.html file
@@ -126,7 +134,7 @@ void get_file(int fd, struct cache *cache, char *request_path)
 
 /**
  * Search for the end of the HTTP header
- * 
+ *
  * "Newlines" in HTTP can be \r\n (carriage return followed by newline) or \n
  * (newline) or \r (carriage return).
  */
@@ -141,6 +149,7 @@ char *find_start_of_body(char *header)
  * Handle HTTP request and send response
  */
 void handle_http_request(int fd, struct cache *cache)
+// this function is where the request is recieved.
 {
     const int request_buffer_size = 65536; // 64K
     char request[request_buffer_size];
@@ -193,7 +202,7 @@ int main(void)
     // This is the main loop that accepts incoming connections and
     // forks a handler process to take care of it. The main parent
     // process then goes back to waiting for new connections.
-    
+
     while(1) {
         socklen_t sin_size = sizeof their_addr;
 
@@ -210,7 +219,7 @@ int main(void)
             get_in_addr((struct sockaddr *)&their_addr),
             s, sizeof s);
         printf("server: got connection from %s\n", s);
-        
+
         // newfd is a new socket descriptor for the new connection.
         // listenfd is still listening for new connections.
 
@@ -223,4 +232,3 @@ int main(void)
 
     return 0;
 }
-


### PR DESCRIPTION
#### Days 1 and 2

- [ ] 1. Implement `send_response()`.

   This function is responsible for formatting all the pieces that make up an HTTP response into the proper format that clients expect. In other words, it needs to build a complete HTTP response with the given parameters. It should write the response to the string in the `response` variable.
   
   The total length of the header **and** body should be stored in the `response_length` variable so that the `send()` call knows how many bytes to
   send out over the wire.

   See the [HTTP](#http) section above for an example of an HTTP response and use that to build your own.

   Hint: `sprintf()` for creating the HTTP response. `strlen()` for computing
   content length. `sprintf()` also returns the total number of bytes in the
   result string, which might be helpful. For getting the current time for the Date field of the response, you'll want to look at the `time()` and `localtime()` functions, both of which are already included in the `time.h` header file.

   > The HTTP `Content-Length` header only includes the length of the body, not
   > the header. But the `response_length` variable used by `send()` is the
   > total length of both header and body.

   You can test whether you've gotten `send_response` working by calling the `resp_404` function from somewhere inside the `main` function, and seeing if the client receives the 404 response. 

- [ ] 2. Examine `handle_http_request()` in the file `server.c`.

   You'll want to parse the first line of the HTTP request header to see if this is a `GET` or `POST` request, and to see what the path is. You'll use this information to decide which handler function to call.

   The variable `request` in `handle_http_request()` holds the entire HTTP request once the `recv()` call returns.

   Read the three components from the first line of the HTTP header. Hint: `sscanf()`.

   Right after that, call the appropriate handler based on the request type
   (`GET`, `POST`) and the path (`/d20` or other file path.) You can start by
   just checking for `/d20` and then add arbitrary files later.

   Hint: `strcmp()` for matching the request method and path. Another hint:
   `strcmp()` returns `0` if the strings are the _same_!

   > Note: you can't `switch()` on strings in C since it will compare the string pointer values instead of the string contents. You have to use an
   > `if`-`else` block with `strcmp()` to get the job done.

   If you can't find an appropriate handler, call `resp_404()` instead to give
   them a "404 Not Found" response.

- [ ] 3. Implement the `get_d20()` handler. This will call `send_response()`.

   See above at the beginning of the assignment for what `get_d20()` should pass to `send_response()`.

   If you need a hint as to what the `send_response()` call should look like, check out the usage of it in `resp_404()`, just above there.

   Note that unlike the other responses that send back file contents, the `d20` endpoint will simply compute a random number and send it back. It does not read the number from a file.

   > The `fd` variable that is passed widely around to all the functions holds a _file descriptor_. It's just a number use to represent an open
   > communications path. Usually they point to regular files on disk, but in
   > this case it points to an open _socket_ network connection. All of the code to create and use `fd` has been written already, but we still need to pass it around to the points it is used.

- [ ] 4. Implement arbitrary file serving.

   Any other URL should map to the `serverroot` directory and files that lie within. For example:

   `http://localhost:3490/index.html` serves file `./serverroot/index.html`.

   `http://localhost:3490/foo/bar/baz.html` serves file
   `./serverroot/foo/bar/baz.html`.

   You might make use of the functionality in `file.c` to make this happen.

   You also need to set the `Content-Type` header depending on what data is in
   the file. `mime.c` has useful functionality for this.