### PR TITLE
docs: fix simple typo, vitually -> virtually

### DIFF
--- a/guides/mime.md
+++ b/guides/mime.md
@@ -42,7 +42,7 @@ Here are some common MIME types:
 
 > _Octet_ is another name for an 8-bit value, commonly known as a _byte_.
 > (Historically the number of bits in a byte varied, even though today they're
-> vitually always 8 bits. An octet is _always_ 8 bits by definition.)
+> virtually always 8 bits. An octet is _always_ 8 bits by definition.)
 
 There are [a lot of MIME
 types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types).


### PR DESCRIPTION
There is a small typo in guides/mime.md.

Should read `virtually` rather than `vitually`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md